### PR TITLE
Fix broken fonts occuring in Stride

### DIFF
--- a/samples/NanoUIDemos/NanoUIDemos.csproj
+++ b/samples/NanoUIDemos/NanoUIDemos.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>

--- a/samples/VeldridExample/VeldridExample.csproj
+++ b/samples/VeldridExample/VeldridExample.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>VeldridExample</RootNamespace>
     <Nullable>disable</Nullable>
     <AssemblyName>VeldridExample</AssemblyName>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/source/Fonts/StbTrueTypeManager.cs
+++ b/source/Fonts/StbTrueTypeManager.cs
@@ -3,6 +3,7 @@ using NanoUI.Nvg;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
+using System.Runtime.InteropServices;
 using static StbTrueTypeSharp.StbTrueType;
 
 namespace NanoUI.Fonts
@@ -26,34 +27,41 @@ namespace NanoUI.Fonts
 
         public bool Load(int fontId, ReadOnlySpan<byte> data, int fontCollectionIndex)
         {
-            fixed (byte* ptr = data)
-            {
-                int stbError;
-                int offset = stbtt_GetFontOffsetForIndex(ptr, fontCollectionIndex);
+            // Copy font data to unmanaged memory so stbtt_fontinfo.data pointer stays valid
+            // after this method returns (the managed byte[] may be GC'd otherwise).
+            // Must use AllocHGlobal since stbtt_fontinfo.Dispose uses Marshal.FreeHGlobal.
+            var dataCopy = (byte*)Marshal.AllocHGlobal(data.Length);
+            data.CopyTo(new Span<byte>(dataCopy, data.Length));
 
-                if (offset == -1)
+            int stbError;
+            int offset = stbtt_GetFontOffsetForIndex(dataCopy, fontCollectionIndex);
+
+            if (offset == -1)
+            {
+                Marshal.FreeHGlobal((nint)dataCopy);
+                stbError = 0;
+            }
+            else
+            {
+                stbtt_fontinfo font = new()
                 {
-                    stbError = 0;
+                    isDataCopy = true // ensure Dispose frees the unmanaged copy
+                };
+                stbError = stbtt_InitFont(font, dataCopy, offset);
+
+                if (stbError != 0)
+                {
+                    // add to dictionary
+                    _fonts[fontId] = font;
                 }
                 else
                 {
-                    stbtt_fontinfo font = new();
-                    stbError = stbtt_InitFont(font, ptr, offset);
-
-                    if (stbError != 0)
-                    {
-                        // add to dictionary
-                        _fonts[fontId] = font;
-                    }
-                    else
-                    {
-                        // todo: throw error?
-                        font.Dispose();
-                    }
+                    // todo: throw error?
+                    font.Dispose();
                 }
-
-                return stbError != 0;
             }
+
+            return stbError != 0;
         }
 
         public void GetFontVMetrics(int fontId, out int ascent, out int descent, out int lineGap)

--- a/source/NanoUI.csproj
+++ b/source/NanoUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Description>Small, extendable and quite feature-rich C# UI library with no external dependencies and no extra assets</Description>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
A while ago I was trying to get the fonts loading in Stride but could not understand why the Font atlas seemed to constantly be different between runs. It seems like an invalid reference to the atlas was being generated from what I understood and this seems to have resolved my issue.

I still dont understand why this issue only occured with Stride and not the Veldrid demo but this change did not break the existing Veldrid implementation so hopefully there are no problems that get brought up by this change.